### PR TITLE
Fix html injection in `formatToHtml`

### DIFF
--- a/decode-spam-headers.py
+++ b/decode-spam-headers.py
@@ -6648,14 +6648,11 @@ def formatToHtml(body, headers):
     body = body.replace(testEnd,   '</div>')
 
     body = body.replace('\n', '<br/>\n').replace('\t', '\t' + '&nbsp;' * 4).replace(' ', '&nbsp;')
-    headers = headers.replace('\n', '<br/>\n').replace('\t', '\t' + '&nbsp;' * 4).replace(' ', '&nbsp;')
     body2 = body
-
     for m in re.finditer(r'(<[^>]+>)', body, re.I):
         a = m.group(1)
         b = a.replace('&nbsp;', ' ')
         body2 = body2.replace(a, b)
-
     body = body2
 
     outputHtml = f'''
@@ -6781,7 +6778,7 @@ blockquote code {{
     font-style: normal;
     font-variant: normal;
     font-weight: 400;
-    line-height: 18.5714px;    
+    line-height: 18.5714px;
 }}
 
 a {{
@@ -6804,9 +6801,9 @@ a {{
           <details>
             <summary>Original SMTP Headers</summary>
             <blockquote>
-            <code>
-{headers}
-            </code>
+            <code><pre>
+{escape(headers)}
+            </pre></code>
             </blockquote>
           </details>
         </article>
@@ -6815,7 +6812,7 @@ a {{
     {body}
   </body>
 </html>
-'''     
+'''
     return outputHtml
 
 def colorizeOutput(out, headers):


### PR DESCRIPTION
Cześć @mgeeky !  Thanks for this script, super useful. :pray: 

A simple drive-by fix here, in html export:
 * If the sample under analysis contains a full-blown `<html>...</html>` blob — interpolating it right into the output report html is not good enough; it **should go through `html.escape()`** first.

Otherwise, contents of email sample bleed out of the `Original SMTP Headers` spoiler, wrecking the report:

![image](https://github.com/user-attachments/assets/75389efe-30e2-49a4-90c7-252495065cc9)

And on the same sample, fixed:

![image](https://github.com/user-attachments/assets/384c5a76-69b7-4a96-b139-b219cf01229a)


Hoping for easy merge, HTH

