### PR TITLE
Fix crash in parsing received hops chain

### DIFF
--- a/decode-spam-headers.py
+++ b/decode-spam-headers.py
@@ -130,6 +130,7 @@ import time
 import atexit
 import base64
 
+from bisect import bisect
 from html import escape
 from email import header as emailheader
 from datetime import *
@@ -2095,7 +2096,7 @@ class SMTPHeadersAnalysis:
             pass
 
         return ''
-            
+
     @staticmethod
     def parseExchangeVersion(lookup):
 
@@ -2104,34 +2105,23 @@ class SMTPHeadersAnalysis:
             if ver.version == lookup:
                 return ver
 
-        lookupparsed = packaging.version.parse(lookup)
-
         # Go with version-wise comparison to fuzzily find proper version name
-        sortedversions = sorted(SMTPHeadersAnalysis.Exchange_Versions)
-
-        match = re.search(r'\d{1,}\.\d{1,}\.\d{1,}', lookup, re.I)
-        if not match:
+        try:
+            lookupparsed = packaging.version.parse(lookup)
+        except packaging.version.InvalidVersion:
             return None
 
-        for i in range(len(sortedversions)):
-            if sortedversions[i].version.startswith(lookup):
-                sortedversions[i].name = 'fuzzy match: ' + sortedversions[i].name
-                return sortedversions[i]
+        sortedversions = sorted(SMTPHeadersAnalysis.Exchange_Versions)
 
-        for i in range(len(sortedversions)):
-            prevver = packaging.version.parse('0.0')
-            nextver = packaging.version.parse('99999.0')
-            if i > 0:
-                prevver = packaging.version.parse(sortedversions[i-1].version)
-            thisver = packaging.version.parse(sortedversions[i].version)
-            if i + 1 < len(sortedversions):
-                nextver = packaging.version.parse(sortedversions[i+1].version)
+        for v in sortedversions:
+            if v.version.startswith(lookup):
+                v.name = 'fuzzy match: ' + v.name
+                return v
 
-            if lookupparsed >= thisver and lookupparsed < nextver:
-                sortedversions[i].name = 'fuzzy match: ' + sortedversions[i].name
-                return sortedversions[i]
-
-        return None
+        inspos = bisect(sortedversions, lookupparsed)
+        sortedversions[inspos].name = 'fuzzy match: {} ({})'.format(
+                sortedversions[inspos].name, lookup)
+        return sortedversions[inspos]
 
 
     def getHeader(self, _header):

--- a/decode-spam-headers.py
+++ b/decode-spam-headers.py
@@ -4992,21 +4992,19 @@ Src: https://www.cisco.com/c/en/us/td/docs/security/esa/esa11-1/user_guide/b_ESA
                 pos += 1
                 continue
 
-            for key in keys:
-                if key in found: continue
-                tmp = False
-                if pos == 0: tmp = True
-                else: tmp = (received[pos-1] in string.whitespace)
+            if pos == 0 or (received[pos-1] in string.whitespace):
+                for key in keys:
+                    if key in found: continue
 
-                if received[pos:].lower().startswith(key + ' ') and tmp:
-                    if lastkey != '':
-                        parsed[lastkey] = received[posOfKey+len(lastkey)+1:pos].strip()
+                    if received[pos:].lower().startswith(key + ' '):
+                        if lastkey != '':
+                            parsed[lastkey] = received[posOfKey+len(lastkey)+1:pos].strip()
 
-                    lastkey = keynow = key
-                    posOfKey = pos
-                    found.add(key)
-                    pos += len(key)
-                    break
+                        lastkey = keynow = key
+                        posOfKey = pos
+                        found.add(key)
+                        pos += len(key)
+                        break
 
             pos += 1
 


### PR DESCRIPTION
Stumbled into a case where `packaging.version.parse` gets fed with `"ffacd0b85a97d-42f7cbd8c20si11690432f8f.269.2025.12.09.06.21.40"` and so crashes with `InvalidVersion` exception.

That ID is clearly not a version string. I also don't see why it ever would be. 🤔 

> o  The ID clause MAY contain an "@" as suggested in [RFC 822](https://www.rfc-editor.org/rfc/rfc822), but this is not required.

-- https://www.rfc-editor.org/rfc/rfc5321#section-4.4

The `ID clause` in `Received:` header -- is supposed to be mta-local "message id"; it's not intended to contain versions. In practice, I see it taking values such as:
 * `ls17csp2524806jab`,
 * `6a1803df08f44-888284b1477si197598466d6.457.2025.12.09.06.21.46`,
 * `A0F173EFD3`,
 * `ffacd0b85a97d-42f89f48092mr11828940f8f.31.1765290101044`,
 * etc.

No idea why the code hopes to find a version string in there; I just stubbed it out so that a None is returned instead of exception, and the report then actually shows the `received` server hops chain.